### PR TITLE
Entry block to function must not have predecessors

### DIFF
--- a/good/entry_block_to_function_must_not_have_predecessors.lat
+++ b/good/entry_block_to_function_must_not_have_predecessors.lat
@@ -1,0 +1,14 @@
+
+boolean calc(boolean b) {
+    return !b;
+}
+
+int foo(boolean b) {
+    while (calc(b));
+    return 0;
+}
+
+int main() {
+    foo(true);
+    return 0;
+}


### PR DESCRIPTION
```
llvm-as: assembly parsed, but does not verify as correct!
Entry block to function must not have predecessors!
label %while.cond.0
```

Invalid LLVM IR:

```
define i32 @foo(i1 %b.0) {
while.cond.0:
    %b1 = call i1 @calc(i1 %b.0)
    br i1 %b1, label %while.cond.0, label %while.end.2
while.end.2:
    ret i32 0
}
```